### PR TITLE
TMDBのAPIキーを環境変数にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 yarn-debug.log*
 .yarn-integrity
 .Ds_Store
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'themoviedb-api', '~> 1.3'
 gem 'pry-rails'
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,10 @@ GEM
     crass (1.0.6)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -251,6 +255,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  dotenv-rails
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4)

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   require 'themoviedb-api'
-  Tmdb::Api.key('533590b90e868ee5686d05e56edc02c1')
+  Tmdb::Api.key(ENV["TMdb_SECRET_KEY"])
   # Tmdb::Api.language("ja") # 映画情報の言語設定を日本語にできる
 
   def index


### PR DESCRIPTION
# What
APIキーを環境変数に変更した

# Why
APIキーをそのままgitにpushしてしまうと他の人に知られてしまい悪用される恐れがある為